### PR TITLE
Resolve GHA deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         python setup.py build_ext --inplace
         pytest --cov=./ -v aldy
     - name: Upload code coverage data
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4.4.1
     - name: Build package
       run: |
         python setup.py sdist
@@ -53,8 +53,8 @@ jobs:
       if: matrix.python-version == '3.7'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.python-version == '3.7'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Update codecov-action to latest to avoid using node12 and 16
Use kebab-case as expected by pypa/gh-action-pypi-publish